### PR TITLE
Make test docker build download go deps for faster test runs.

### DIFF
--- a/test.dockerfile
+++ b/test.dockerfile
@@ -5,4 +5,8 @@ WORKDIR /go/src/github.com/eddie023/byd
 RUN apt-get update \
     && apt-get install -y -q --no-install-recommends 
 
+# Download all go dependencies in the image to make tests runs faster.
+COPY go.mod .
+RUN go mod download -x
+
 ENTRYPOINT [ "/bin/sh", "-c", "go test $(go list --buildvcs=false ./...)" ]


### PR DESCRIPTION
This change makes test runs go from taking 19 seconds to 10 seconds on my machine.

Faster test runs mean tighter feedback loop!

The COPY line's sha-256 seems to include the source go.mod, so when that changes, the image automatically gets re-built on next `make test`, re-fetching all dependencies again (not ideal, and the new one.